### PR TITLE
代码段装载

### DIFF
--- a/arch/arm64/kernel/module.c
+++ b/arch/arm64/kernel/module.c
@@ -6,7 +6,8 @@
  *
  * Author: Will Deacon <will.deacon@arm.com>
  */
-
+#include "linux/sizes.h"
+#define DEBUG
 #define pr_fmt(fmt) "Modules: " fmt
 
 #include <linux/bitops.h>
@@ -80,10 +81,14 @@ static int __init module_init_limits(void)
 	BUILD_BUG_ON(MODULES_VSIZE < SZ_2G);
 
 	if (!kaslr_enabled()) {
-		if (kernel_size < SZ_128M)
-			module_direct_base = kernel_end - SZ_128M;
-		if (kernel_size < SZ_2G)
-			module_plt_base = kernel_end - SZ_2G;
+		if (kernel_size < SZ_128M) {
+			// module_direct_base = kernel_end - SZ_128M;
+			module_direct_base = kernel_start;
+		}
+		if (kernel_size < SZ_2G) {
+			// module_plt_base = kernel_end - SZ_2G;
+			module_plt_base = kernel_start;
+		}
 	} else {
 		u64 min = kernel_start;
 		u64 max = kernel_end;
@@ -134,6 +139,102 @@ void *module_alloc(unsigned long size)
 					 GFP_KERNEL | __GFP_NOWARN,
 					 PAGE_KERNEL, 0, NUMA_NO_NODE,
 					 __builtin_return_address(0));
+	}
+
+	if (!p) {
+		pr_warn_ratelimited("%s: unable to allocate memory\n",
+				    __func__);
+	}
+
+	if (p && (kasan_alloc_module_shadow(p, size, GFP_KERNEL) < 0)) {
+		vfree(p);
+		return NULL;
+	}
+
+	/* Memory is intended to be executable, reset the pointer tag. */
+	return kasan_reset_tag(p);
+}
+
+
+void *module_alloc_type(unsigned long size, enum mod_mem_type type)
+{
+	void *p = NULL;
+	pr_debug("Arm64 module_alloc_type");
+	/*
+	 * Where possible, prefer to allocate within direct branch range of the
+	 * kernel such that no PLTs are necessary.
+	 */
+	if (module_direct_base) {
+		if (mod_mem_type_is_in(type)) {
+			pr_debug("\ttype %d uses: 0x%llx - 0x%llx", 
+				type, module_direct_base + SZ_64M, module_direct_base + SZ_128M);
+			p = __vmalloc_node_range(size, MODULE_ALIGN,
+						module_direct_base + SZ_64M,
+						module_direct_base + SZ_128M,
+						GFP_KERNEL | __GFP_NOWARN,
+						PAGE_KERNEL, 0, NUMA_NO_NODE,
+						__builtin_return_address(0));
+		} else if (mod_mem_type_is_out(type)) {
+			pr_debug("\ttype %d uses: 0x%llx - 0x%llx", 
+				type, module_direct_base + SZ_64M + SZ_32M, module_direct_base + SZ_128M);
+			p = __vmalloc_node_range(size, MODULE_ALIGN,
+						module_direct_base + SZ_64M + SZ_32M,
+						module_direct_base + SZ_128M,
+						GFP_KERNEL | __GFP_NOWARN,
+						PAGE_KERNEL, 0, NUMA_NO_NODE,
+						__builtin_return_address(0));
+		} else {
+			pr_debug("\ttype %d uses: 0x%llx - 0x%llx", 
+				type, module_direct_base, module_direct_base + SZ_64M);
+			p = __vmalloc_node_range(size, MODULE_ALIGN,
+						module_direct_base,
+						module_direct_base + SZ_64M,
+						GFP_KERNEL | __GFP_NOWARN,
+						PAGE_KERNEL, 0, NUMA_NO_NODE,
+						__builtin_return_address(0));
+		}
+		if (!p) {
+			pr_debug("\tmodule_direct_base failed");
+		}
+	}
+	if (!p && module_plt_base) {
+		if (mod_mem_type_is_in(type)) {
+			pr_debug("\ttype %d uses: 0x%llx - 0x%llx", 
+				type, module_plt_base + SZ_1G, module_plt_base + SZ_1G + SZ_512M);
+			p = __vmalloc_node_range(size, MODULE_ALIGN,
+						module_plt_base + SZ_1G,
+						module_plt_base + SZ_1G + SZ_512M,
+						GFP_KERNEL | __GFP_NOWARN,
+						PAGE_KERNEL, 0, NUMA_NO_NODE,
+						__builtin_return_address(0));
+		} else if (mod_mem_type_is_out(type)) {
+			pr_debug("\ttype %d uses: 0x%llx - 0x%llx", 
+				type, module_plt_base + SZ_1G + SZ_512M, module_plt_base + SZ_2G);
+			p = __vmalloc_node_range(size, MODULE_ALIGN,
+						module_plt_base + SZ_1G + SZ_512M,
+						module_plt_base + SZ_2G,
+						GFP_KERNEL | __GFP_NOWARN,
+						PAGE_KERNEL, 0, NUMA_NO_NODE,
+						__builtin_return_address(0));
+		} else {
+			pr_debug("\ttype %d uses: 0x%llx - 0x%llx", 
+				type, module_plt_base, module_plt_base + SZ_1G);
+			p = __vmalloc_node_range(size, MODULE_ALIGN,
+						module_plt_base,
+						module_plt_base + SZ_1G,
+						GFP_KERNEL | __GFP_NOWARN,
+						PAGE_KERNEL, 0, NUMA_NO_NODE,
+						__builtin_return_address(0));
+		}
+		// p = __vmalloc_node_range(size, MODULE_ALIGN,
+		// 			 module_plt_base,
+		// 			 module_plt_base + SZ_2G,
+		// 			 GFP_KERNEL | __GFP_NOWARN,
+		// 			 PAGE_KERNEL, 0, NUMA_NO_NODE,
+		// 			 __builtin_return_address(0));
+		if (!p) {
+			pr_debug("\tmodule_plt_base failed");
+		}
 	}
 
 	if (!p) {

--- a/include/linux/module.h
+++ b/include/linux/module.h
@@ -323,10 +323,14 @@ struct mod_tree_node {
 
 enum mod_mem_type {
 	MOD_TEXT = 0,
+	MOD_TEXT_IN,
+	MOD_TEXT_OUT,
 	MOD_DATA,
 	MOD_RODATA,
 	MOD_RO_AFTER_INIT,
 	MOD_INIT_TEXT,
+	MOD_INIT_TEXT_IN,
+	MOD_INIT_TEXT_OUT,
 	MOD_INIT_DATA,
 	MOD_INIT_RODATA,
 
@@ -335,29 +339,43 @@ enum mod_mem_type {
 };
 
 #define mod_mem_type_is_init(type)	\
-	((type) == MOD_INIT_TEXT ||	\
-	 (type) == MOD_INIT_DATA ||	\
+	((type) == MOD_INIT_TEXT ||		\
+	 (type) == MOD_INIT_TEXT_IN ||	\
+	 (type) == MOD_INIT_TEXT_OUT ||	\
+	 (type) == MOD_INIT_DATA ||		\
 	 (type) == MOD_INIT_RODATA)
 
 #define mod_mem_type_is_core(type) (!mod_mem_type_is_init(type))
 
 #define mod_mem_type_is_text(type)	\
-	 ((type) == MOD_TEXT ||		\
-	  (type) == MOD_INIT_TEXT)
+	 ((type) == MOD_TEXT ||			\
+	  (type) == MOD_TEXT_IN || 		\
+	  (type) == MOD_TEXT_OUT || 	\
+	  (type) == MOD_INIT_TEXT || 	\
+	  (type) == MOD_INIT_TEXT_IN || \
+	  (type) == MOD_INIT_TEXT_OUT)
 
 #define mod_mem_type_is_data(type) (!mod_mem_type_is_text(type))
 
-#define mod_mem_type_is_core_data(type)	\
-	(mod_mem_type_is_core(type) &&	\
+#define mod_mem_type_is_core_data(type)		\
+	(mod_mem_type_is_core(type) &&			\
 	 mod_mem_type_is_data(type))
 
 #define for_each_mod_mem_type(type)			\
 	for (enum mod_mem_type (type) = 0;		\
 	     (type) < MOD_MEM_NUM_TYPES; (type)++)
 
-#define for_class_mod_mem_type(type, class)		\
-	for_each_mod_mem_type(type)			\
+#define for_class_mod_mem_type(type, class)	\
+	for_each_mod_mem_type(type)				\
 		if (mod_mem_type_is_##class(type))
+
+#define mod_mem_type_is_in(type)	\
+	((type) == MOD_TEXT_IN ||		\
+	 (type) == MOD_INIT_TEXT_IN)
+
+#define mod_mem_type_is_out(type)	\
+	((type) == MOD_TEXT_OUT ||		\
+	 (type) == MOD_INIT_TEXT_OUT)
 
 struct module_memory {
 	void *base;

--- a/include/linux/moduleloader.h
+++ b/include/linux/moduleloader.h
@@ -28,6 +28,7 @@ unsigned int arch_mod_section_prepend(struct module *mod, unsigned int section);
 /* Allocator used for allocating struct module, core sections and init
    sections.  Returns NULL on failure. */
 void *module_alloc(unsigned long size);
+void *module_alloc_type(unsigned long size, enum mod_mem_type type);
 
 /* Free memory returned from module_alloc. */
 void module_memfree(void *module_region);

--- a/include/uapi/linux/elf.h
+++ b/include/uapi/linux/elf.h
@@ -293,6 +293,8 @@ typedef struct elf64_phdr {
 #define SHF_EXECINSTR		0x4
 #define SHF_RELA_LIVEPATCH	0x00100000
 #define SHF_RO_AFTER_INIT	0x00200000
+#define SHF_TRAMPO_IN 0x00400000
+#define SHF_TRAMPO_OUT 0x00800000
 #define SHF_MASKPROC		0xf0000000
 
 /* special section indexes */

--- a/samples/Kconfig
+++ b/samples/Kconfig
@@ -6,6 +6,9 @@ menuconfig SAMPLES
 
 if SAMPLES
 
+config SAMPLE_TEST_MODULE
+	tristate "test module"
+
 config SAMPLE_AUXDISPLAY
 	bool "auxdisplay sample"
 	depends on CC_CAN_LINK

--- a/samples/Makefile
+++ b/samples/Makefile
@@ -18,6 +18,7 @@ subdir-$(CONFIG_SAMPLE_PIDFD)		+= pidfd
 obj-$(CONFIG_SAMPLE_QMI_CLIENT)		+= qmi/
 obj-$(CONFIG_SAMPLE_RPMSG_CLIENT)	+= rpmsg/
 subdir-$(CONFIG_SAMPLE_SECCOMP)		+= seccomp
+obj-$(CONFIG_SAMPLE_TEST_MODULE)	+= test_module/
 subdir-$(CONFIG_SAMPLE_TIMER)		+= timers
 obj-$(CONFIG_SAMPLE_TRACE_EVENTS)	+= trace_events/
 obj-$(CONFIG_SAMPLE_TRACE_CUSTOM_EVENTS) += trace_events/

--- a/samples/test_module/Makefile
+++ b/samples/test_module/Makefile
@@ -1,0 +1,4 @@
+# SPDX-License-Identifier: GPL-2.0-only
+KBUILD_CFLAGS += -ffunction-sections
+obj-$(CONFIG_SAMPLE_TEST_MODULE) += test_module.o
+# CFLAGS_f_fs.o += -fpass-plugin=/root/llvm-tutor/build/lib/libBoundaryCounter.so

--- a/samples/test_module/test_module.c
+++ b/samples/test_module/test_module.c
@@ -1,0 +1,70 @@
+// test_module.c
+#include <linux/init.h>
+#include <linux/module.h>
+#include <linux/kernel.h>
+
+MODULE_LICENSE("GPL");
+MODULE_AUTHOR("Kuan");
+MODULE_DESCRIPTION("A simple test module");
+MODULE_VERSION("1.0");
+
+typedef void (*func_ptr) (void);
+
+int  __attribute__ ((visibility("hidden"))) printk_trampoline_out(const char *fmt, ...)
+{
+    va_list args;
+    int r;
+
+    va_start(args, fmt);
+    r = vprintk(fmt, args);
+    va_end(args);
+
+    return r;
+}
+
+void func1(void) {
+    printk_trampoline_out(KERN_INFO "\tthis is func1\n");
+}
+void func2(void) {
+    printk_trampoline_out(KERN_INFO "\tthis is func2\n");
+}
+void func3(void) {
+    printk_trampoline_out(KERN_INFO "\tthis is func3\n");
+}
+void func4(void) {
+    printk_trampoline_out(KERN_INFO "\tthis is func4\n");
+}
+
+static int __init test_module_init(void);
+
+void test_trampoline_in(int argv);
+
+void  __attribute__ ((__noinline__, visibility("hidden"))) test(int argv) {
+    void *caller = __builtin_return_address(0);
+
+    // TODO: check caller is in test_trampoline_in
+    if (0) {
+        printk_trampoline_out(KERN_INFO "\tcalled by test_trampoline_in.\n");
+    }
+
+    func_ptr jt[4] = {func1, func2, func3, func4};
+    jt[argv]();
+}
+
+void __attribute__ ((__noinline__)) test_trampoline_in(int argv) {
+    test(argv);
+}
+
+static int __init test_module_init(void) {
+    printk_trampoline_out(KERN_INFO "Test module loaded.\n");
+    for (int i = 0; i < 4; ++i) 
+        test_trampoline_in(i);
+    return 0;
+}
+
+static void __exit test_module_exit(void) {
+    printk_trampoline_out(KERN_INFO "Test module unloaded.\n");
+}
+
+module_init(test_module_init);
+module_exit(test_module_exit);


### PR DESCRIPTION
内核模块代码段装载。装载时进行一次随机化，并为持续随机化提供基础。
Trampoline_out 需要装载到特定位置，以方便进行 CFI 检查。