### PR TITLE
使用长 watchpoint

### DIFF
--- a/arch/arm64/include/asm/hw_breakpoint.h
+++ b/arch/arm64/include/asm/hw_breakpoint.h
@@ -12,6 +12,7 @@
 
 struct arch_hw_breakpoint_ctrl {
 	u32 __reserved	: 19,
+	mask	: 4,
 	len		: 8,
 	type		: 2,
 	privilege	: 2,
@@ -33,7 +34,7 @@ struct arch_hw_breakpoint {
 static inline u32 encode_ctrl_reg(struct arch_hw_breakpoint_ctrl ctrl)
 {
 	u32 val = (ctrl.len << 5) | (ctrl.type << 3) | (ctrl.privilege << 1) |
-		ctrl.enabled;
+		(ctrl.mask << 24) | ctrl.enabled;
 
 	if (is_kernel_in_hyp_mode() && ctrl.privilege == AARCH64_BREAKPOINT_EL1)
 		val |= DBG_HMC_HYP;

--- a/arch/arm64/include/asm/ptrace.h
+++ b/arch/arm64/include/asm/ptrace.h
@@ -201,6 +201,9 @@ struct pt_regs {
 	/* Only valid for some EL1 exceptions. */
 	u64 lockdep_hardirqs;
 	u64 exit_rcu;
+
+	u64 xx;
+	u64 yy;
 };
 
 static inline bool in_syscall(struct pt_regs const *regs)

--- a/arch/arm64/kernel/asm-offsets.c
+++ b/arch/arm64/kernel/asm-offsets.c
@@ -81,6 +81,8 @@ int main(void)
   DEFINE(S_SDEI_TTBR1,		offsetof(struct pt_regs, sdei_ttbr1));
   DEFINE(S_PMR_SAVE,		offsetof(struct pt_regs, pmr_save));
   DEFINE(S_STACKFRAME,		offsetof(struct pt_regs, stackframe));
+  DEFINE(S_xx,		offsetof(struct pt_regs, xx));
+  DEFINE(S_yy,		offsetof(struct pt_regs, yy));
   DEFINE(PT_REGS_SIZE,		sizeof(struct pt_regs));
   BLANK();
 #ifdef CONFIG_DYNAMIC_FTRACE_WITH_ARGS

--- a/arch/arm64/kernel/entry.S
+++ b/arch/arm64/kernel/entry.S
@@ -217,6 +217,11 @@ alternative_cb_end
 	stp	x24, x25, [sp, #16 * 12]
 	stp	x26, x27, [sp, #16 * 13]
 	stp	x28, x29, [sp, #16 * 14]
+	
+	mrs x0, DBGWVR0_EL1
+	mrs x1, DBGWCR0_EL1
+	str x0, [sp, #S_xx]
+	str x1, [sp, #S_yy]
 
 	.if	\el == 0
 	clear_gp_regs
@@ -408,7 +413,12 @@ alternative_else_nop_endif
 
 	apply_ssbd 0, x0, x1
 	.endif
-
+	
+	ldr x0, [sp, #S_xx]
+	ldr x1, [sp, #S_yy]
+	msr DBGWVR0_EL1, x0
+	msr DBGWCR0_EL1, x1
+	
 	msr	elr_el1, x21			// set up the return data
 	msr	spsr_el1, x22
 	ldp	x0, x1, [sp, #16 * 0]

--- a/arch/arm64/kernel/hw_breakpoint.c
+++ b/arch/arm64/kernel/hw_breakpoint.c
@@ -461,6 +461,16 @@ static int arch_build_bp_info(struct perf_event *bp,
 		return -EINVAL;
 	}
 
+	/* Mask */
+	if (attr->bp_mask) {
+ 		/* Mask */
+ 		// if (attr->bp_mask < 3 || attr->bp_mask > 31) return -EINVAL;
+ 		// if (attr->bp_addr & ((1 << attr->bp_mask) - 1)) return -EINVAL;
+ 		if (attr->bp_len != HW_BREAKPOINT_LEN_8) return -EINVAL;
+ 		hw->ctrl.len = ARM_BREAKPOINT_LEN_8;
+ 		hw->ctrl.mask = attr->bp_mask + 1;
+	}
+
 	/*
 	 * On AArch64, we only permit breakpoints of length 4, whereas
 	 * AArch32 also requires breakpoints of length 2 for Thumb.

--- a/include/uapi/linux/perf_event.h
+++ b/include/uapi/linux/perf_event.h
@@ -464,6 +464,7 @@ struct perf_event_attr {
 	};
 
 	__u32			bp_type;
+	__u32			bp_mask;
 	union {
 		__u64		bp_addr;
 		__u64		kprobe_func; /* for perf_kprobe */

--- a/samples/hw_breakpoint/Makefile
+++ b/samples/hw_breakpoint/Makefile
@@ -1,2 +1,2 @@
 # SPDX-License-Identifier: GPL-2.0-only
-obj-$(CONFIG_SAMPLE_HW_BREAKPOINT) += data_breakpoint.o
+obj-$(CONFIG_SAMPLE_HW_BREAKPOINT) += data_breakpoint.o watchpoint.o trampoline.o

--- a/samples/hw_breakpoint/trampoline.c
+++ b/samples/hw_breakpoint/trampoline.c
@@ -1,0 +1,24 @@
+#include <linux/module.h>	/* Needed by all modules */
+#include <linux/kernel.h>	/* Needed for KERN_INFO */
+#include <linux/init.h>		/* Needed for the macros */
+
+#include <trampoline.h>
+
+u64 trampoline[TRAMPOLINE_LEN];
+EXPORT_SYMBOL_GPL(trampoline);
+
+static int __init trampoline_init(void) {
+	printk(KERN_INFO "Trampolines mod loaded\n");
+	return 0;
+}
+
+static void __exit trampoline_exit(void) {
+	printk(KERN_INFO "Trampolines mod unloaded\n");
+}
+
+module_init(trampoline_init);
+module_exit(trampoline_exit);
+
+MODULE_LICENSE("GPL");
+MODULE_AUTHOR("Kuan");
+MODULE_DESCRIPTION("Trampoline");

--- a/samples/hw_breakpoint/trampoline.h
+++ b/samples/hw_breakpoint/trampoline.h
@@ -1,0 +1,1 @@
+#define TRAMPOLINE_LEN 512

--- a/samples/hw_breakpoint/watchpoint.c
+++ b/samples/hw_breakpoint/watchpoint.c
@@ -1,0 +1,108 @@
+#include <linux/module.h>	/* Needed by all modules */
+#include <linux/kernel.h>	/* Needed for KERN_INFO */
+#include <linux/init.h>		/* Needed for the macros */
+#include <linux/kallsyms.h>
+#include <linux/delay.h>
+#include <linux/random.h>
+#include <linux/kthread.h>
+
+#include <linux/perf_event.h>
+#include <linux/hw_breakpoint.h>
+
+#include <trampoline.h>
+
+#define RANDPERIOD 2000
+
+static struct task_struct *kthread = NULL;
+
+struct perf_event * __percpu *wp;
+struct perf_event * __percpu *cpu_events;
+struct perf_event_attr attr;
+
+static char ksym_name[KSYM_NAME_LEN] = "trampoline";
+module_param_string(ksym, ksym_name, KSYM_NAME_LEN, S_IRUGO);
+
+static void watchpoint_handler(struct perf_event *bp,
+			       struct perf_sample_data *data,
+			       struct pt_regs *regs) {
+	// printk(KERN_INFO "%s value is read\n", ksym_name);
+	// dump_stack();
+	printk(KERN_INFO "Dump stack from sample_hbp_handler\n");
+	return;
+}
+
+int work_func(void *trampoline) {
+	/*
+	读写操作次数 1000，单位 ns
+	实验：开启 watchpoint，对 trampolines 做读写，每次读写前关闭 watchpoint，读写后重新开启 45527488 42475872 54561136 42120944 42446912 45426470.4  45426.4704
+	     关闭 watchpoint，对 trampolines 做读写，                                     10240    10464    11632    11312    10336    10796.8     10.7968   0.682%
+		 开启 watchpoint，对未监视区域做读写，每次读写前不需要关闭 watchpoint              10288    11440    10240    11856    10528    10870.4     10.8704
+		 开启 watchpoint，对 trampolines 做读写，在所有读写前关闭 watchpoint，所有读写后重新开启，只操作一次 watchpoint
+		 																	    ,  2295440  2445024  2412240  2169936  2171184  2298764.8   2298.7648
+	*/
+	int i;
+	ktime_t time;
+	// int cpu = get_cpu();
+	u64 *trampolines = (u64 *)trampoline;
+	
+	printk(KERN_INFO "Visiting trampolines\n");
+	time = ktime_get();
+	// unregister_hw_breakpoint(per_cpu(*wp, cpu));
+	for (i = TRAMPOLINE_LEN - 1; i >= 0; i--) {
+		printk(KERN_INFO "%dth entry in trampolines ", i);
+		printk(KERN_INFO "0x%x\n", trampolines[i]);
+		// trampolines[i] = 0xd61f0000;
+	}
+	// wp = perf_event_create_kernel_counter(&attr, cpu, NULL, watchpoint_handler, context);
+	// if (IS_ERR(wp)) return PTR_ERR(wp);
+	// per_cpu(*cpu_events, cpu) = wp;
+	printk(KERN_INFO "Total time: %lld\n", ktime_get() - time);
+	
+	return 0;
+}
+
+
+static int __init watchpoint_init(void) {
+	int ret;
+	void *addr = __symbol_get(ksym_name);
+
+	if (!addr) return -ENXIO;
+	printk(KERN_INFO "ksym %s in %p", ksym_name, addr);
+
+	hw_breakpoint_init(&attr);
+	attr.bp_mask = 11;
+	attr.bp_addr = (unsigned long)addr;
+	attr.bp_len = HW_BREAKPOINT_LEN_8;
+	attr.bp_type = HW_BREAKPOINT_R;
+
+	wp = register_wide_hw_breakpoint(&attr, watchpoint_handler, NULL);
+	if (IS_ERR((void __force *)wp)) {
+		ret = PTR_ERR((void __force *)wp);
+        printk(KERN_INFO "Watchpoint registration failed\n");
+        return ret;
+	}
+	printk(KERN_INFO "Watchpoint for %s installed %p\n", ksym_name, addr);
+
+	/* Start worker kthread */
+	kthread = kthread_run(work_func, (void *)addr, "tl_writer");
+	if(kthread == ERR_PTR(-ENOMEM)){
+		pr_err("Could not run kthread\n");
+		return -1;
+	}
+	printk(KERN_INFO "Kernel thread start\n");
+	
+	return 0;
+}
+
+static void __exit watchpoint_exit(void) {
+	unregister_wide_hw_breakpoint(wp);
+	symbol_put(ksym_name);
+	printk(KERN_INFO "Watchpoint for %s write uninstalled\n", ksym_name);
+}
+
+module_init(watchpoint_init);
+module_exit(watchpoint_exit);
+
+MODULE_LICENSE("GPL");
+MODULE_AUTHOR("Kuan");
+MODULE_DESCRIPTION("Watchpoint");


### PR DESCRIPTION
以下是目前的问题：
1. Linux6.6 没有启用长 watchpoint，只支持 8 字节 watchpoint。
2. Watchpoint 回调函数触发有问题。
3. 为系统调用使用 watchpoint 进行切换。避免 watchpoint 冲突。